### PR TITLE
Fix postgresql executable name to psql

### DIFF
--- a/app/controllers/misc_controller.rb
+++ b/app/controllers/misc_controller.rb
@@ -4,7 +4,7 @@ class MiscController < SecureController
       openssl: OpenSSL::OPENSSL_VERSION.split(' ')[1],
       ruby: `ruby -v`.split(' ')[1],
       rails: `rails -v`.split(' ')[1],
-      postgres: `postgres -V`.split(' ')[2],
+      postgres: `psql -V`.split(' ')[2],
     }
   end
 end


### PR DESCRIPTION
On Ubuntu 17.10, the `postgresql` does not exist. It's `psql`.